### PR TITLE
bug(webpackExport): fix issues with exports

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
-module.export = {
+module.exports = {
     entry: './src/index.js',
     output: {
         path: path.join(__dirname, '/dist'),


### PR DESCRIPTION
#### What does this PR do?
Fix the error :

You may need an appropriate loader to handle this file type.
| import App from './components/App';
|
> ReactDOM.render(<App />, document.getElementById('app'));
|
 @ multi (webpack)-dev-server/client?http://localhost:8080 (webpack)/hot/dev-server.js ./src main[2]

#### Description of Task to be completed?
- change module.export to module.exports in webpack.config.js

#### How should this be manually tested?
Clone this repo
navigate to the root directory and run npm install
after the installation of the node_modules, run npm start

#### Any background context you want to provide?


#### What are the relevant pivotal tracker stories?

#### Screenshots (if appropriate)

#### Questions:
